### PR TITLE
DisplayManager

### DIFF
--- a/src/mqe/_emulator.py
+++ b/src/mqe/_emulator.py
@@ -477,6 +477,10 @@ class Emulator:
         # execute instruction
         self._instruction_set[opcode](rom_cache_bus)
 
+        # display manager
+        if DisplayManager.ROOT is not None:
+            DisplayManager.ROOT.update()
+
         # add to time
         self.instruction_counter += 1
         if memory_flag:
@@ -501,6 +505,8 @@ class Emulator:
                 break
             except IndexError:
                 print("WARN: program counter overflow; halted")
+                break
+            except KeyboardInterrupt:
                 break
         print(f"\n\n{'='*120}\n")
         print(f"Finished after : {self.instruction_counter} instructions")

--- a/src/mqe/_main.py
+++ b/src/mqe/_main.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 from . import Emulator
+from threading import Thread
 
 
 parser = argparse.ArgumentParser(prog="mqe", description="Emulates .mqa execution files for Mini Quantum CPU")
@@ -25,9 +26,12 @@ def main():
     if not os.path.isfile(args.input):
         die(f"file '{args.input}' not found")
 
+    # initialize the emulator
     emulator = Emulator(verbose=args.verbose)
     with open(args.input, "rb") as file:
         emulator.load_binary_file(file)
+
+    # run emulation
     emulator.execute_whole()
 
 

--- a/src/mqe/ext/_display.py
+++ b/src/mqe/ext/_display.py
@@ -14,7 +14,43 @@ class DisplayManager:
     2 for page mode
     """
 
-    INITIATED: bool = False
+    # display manager parameters
+    INITIALIZED: bool = False
+
+    # window variables
+    ROOT = None
+    IMAGE_BUFFER = None
+
+    # window width and height
+    WINDOW_WIDTH = 128
+    WINDOW_HEIGHT = 128
+
+    @classmethod
+    def initialize(cls, mode: int):
+        """
+        Initializes the display
+        """
+
+        # initialize Tk
+        from tkinter import Tk, Canvas, PhotoImage, mainloop
+
+        # create a window
+        cls.ROOT = Tk()
+        if mode == 1:
+            cls.ROOT.title("DisplayManager (XY mode)")
+        else:
+            cls.ROOT.title("DisplayManager (page mode)")
+
+        # make canvas
+        canvas = Canvas(cls.ROOT, width=cls.WINDOW_WIDTH, height=cls.WINDOW_HEIGHT, bg="#000000")
+        canvas.pack()
+
+        # create window image buffer and put it on canvas
+        cls.IMAGE_BUFFER = PhotoImage(width=cls.WINDOW_WIDTH, height=cls.WINDOW_HEIGHT)
+        canvas.create_image((cls.WINDOW_WIDTH//2, cls.WINDOW_HEIGHT//2), image=cls.IMAGE_BUFFER, state="normal")
+
+        # start the window
+        mainloop()
 
     @classmethod
     def process(cls, emu):
@@ -27,10 +63,12 @@ class DisplayManager:
         if emu.ports[0] != 1 and emu.ports[0] != 2:
             return
 
-        if not cls.INITIATED:
-            os.system("")
-            print("\n".join([' ' * 120 for _ in range(30)]))
-            cls.INITIATED = True
+        # check initialization
+        if not cls.INITIALIZED:
+            cls.initialize(emu.ports[0])
+
+            # set INITIALIZED to True
+            cls.INITIALIZED = True
 
         # XY mode
         if emu.ports[0] == 1:

--- a/src/mqe/ext/_display.py
+++ b/src/mqe/ext/_display.py
@@ -1,6 +1,4 @@
-from time import sleep
 from tkinter import Tk, Canvas, PhotoImage
-from threading import Thread
 
 
 """


### PR DESCRIPTION
Adds a new simplistic display manager

There are 2 modes:
* 1 - XY mode
* 2 - Page mode (WIP)

When included, must be initialized first.
* port 0 - interrupt module to call, 1 for XY mode display, 2 for page mode display
* port 1 - window width
* port 2 - window height
Initialization process is done once.

To plot a pixel in XY mode, an interrupt must be called with:
* port 0 - 1
* port 1 - X position
* port 2 - Y position
* port 3 - RGB value

The RGB value is a 1 byte value, where bits go as follows `RRRGGGBB`

For now the page mode is not made, but in theory there will be an initialization step:
* port 0 - 2 for page mode
* port 1 - window width (up to 127)
* port 2 - window height (up to 127)
* port 3 - color mode

Color mode will be an integer, representing on how colors will be stored in memory (cache)
* Color mode 0 - black and white, 1 bit per pixel
* Color mode 1 - very limited colors, 4 bits per pixel (may be a color palette stored in cache as well)
* Color mode 2 - limited colors, 8 bits per pixel
* Color mode 3 - all colors, 24 bits per pixel

Note that the cache usage SHOULD limited to 32 KiB. There will be no hard limit added, and no checks, so if you decide to use the entire cache, it will be possible, but not more than 65 KiB (16 bit address bus width limitation)